### PR TITLE
Fixate the version of jaeger agent. The latest version of the image d…

### DIFF
--- a/k8s/mongonaut/templates/deployment.yaml
+++ b/k8s/mongonaut/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - image: jaegertracing/jaeger-agent
+        - image: jaegertracing/jaeger-agent:1.16
           name: {{ .Chart.Name }}-jaeger-agent
           ports:
           - containerPort: 5775


### PR DESCRIPTION
The latest version of the `jaegertracing/jaeger-agent` (1.17) image doesn't work with mongonaut.